### PR TITLE
Swap targets, updated 4 site targets to be objects and updated site_data to be file format

### DIFF
--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -1,14 +1,14 @@
 #' Getting NWIS Data 
 #'
 #' @param site_num character, a site number for a USGS streamgage
-#' @param file_out csv, csv exported for each designated site_num
+#' @param file_out csv, csv exported with data on all 4 site_num
 #' @param parameterCd, parameter code corresponding to the type of data queried
 #' @param startDate 
 #' @param endDate 
 #'
-#' @export csvs,export 5 csvs: site_info.csv, nwis_01427207_data.csv, nwis_01432160_data.csv, nwis_01436690_data.csv, & nwis_01466500_data.csv. 
+#' @export csvs,export 2 csvs: site_data.csv and site_info.csv
 
-download_nwis_site_data <- function(file_out, site_num, parameterCd, startDate, endDate){
+download_nwis_site_data <- function(site_num, parameterCd, startDate, endDate){
 
   # readNWISdata is from the dataRetrieval package
   data_out <- readNWISdata(sites=site_num, service="iv", 
@@ -21,18 +21,19 @@ download_nwis_site_data <- function(file_out, site_num, parameterCd, startDate, 
   }
   # -- end of do-not-edit block
   
-  write_csv(data_out, file = file_out)
-  return(file_out)
+  return(data_out)
 }
 
-# bind csvs so we can get site_info  
-sites_csvs <- function(file_in){
-  lapply(file_in, read_csv) %>% 
-    bind_rows()
+# bind data so we can get site_info  
+sites <- function(input, file_out){
+    bind_rows(input) %>% 
+    write_csv(file = file_out)
+  return(file_out)
 }
 
 # obtain site info, includes cols such as: station_nm, site_tp, lat_va, long_va, etc.
 nwis_site_info <- function(file_out, site_data){
+  site_data <- read_csv(site_data)
   site_no <- unique(site_data$site_no)
   site_info <- dataRetrieval::readNWISsite(site_no)
   write_csv(site_info, file_out)

--- a/2_process/src/process_and_style.R
+++ b/2_process/src/process_and_style.R
@@ -1,11 +1,12 @@
 #' Processing and styling site data 
-#' @param file_in 
+#' @param file_in csv, site_data_csv includes cols site_no, X_00010_00000, X_00010_00000_cd, and tz_cd for each site 
 #' @param site_filename csv, site_info.csv includes cols such as: station_nm, site_tp, lat_va, long_va, etc. for each site. 
 #' @return df, contains cleaned data for plotting time series
 
 process_data <- function(file_in, site_filename){
   site_info <- read_csv(site_filename)
-  nwis_data_clean <- rename(file_in, water_temperature = X_00010_00000) %>% 
+  nwis_data_clean <- read_csv(file_in) %>% 
+  rename(water_temperature = X_00010_00000) %>% 
     select(-agency_cd, -X_00010_00000_cd, -tz_cd) %>% 
     left_join(site_info, by = "site_no") %>% 
     select(station_name = station_nm, site_no, dateTime, water_temperature, latitude = dec_lat_va, longitude = dec_long_va) %>% 

--- a/_targets.R
+++ b/_targets.R
@@ -13,36 +13,30 @@ endDate <- "2015-05-01"
 
 p1_targets_list <- list(
   tar_target(
-    site_data_01427207_csv,
-    download_nwis_site_data(file_out = '1_fetch/out/nwis_01427207_data.csv',
-    site_num = '01427207', parameterCd = parameterCd, startDate = startDate, endDate = endDate),
-    format = "file"
+    site_data_01427207,
+    download_nwis_site_data(site_num = '01427207', parameterCd = parameterCd, startDate = startDate, endDate = endDate)
     ),
   tar_target(
-    site_data_01432160_csv,
-    download_nwis_site_data(file_out = '1_fetch/out/nwis_01432160_data.csv',
-    site_num = '01432160', parameterCd = parameterCd, startDate = startDate, endDate = endDate), 
-    format = "file"
+    site_data_01432160,
+    download_nwis_site_data(site_num = '01432160', parameterCd = parameterCd, startDate = startDate, endDate = endDate)
   ),
   tar_target(
-    site_data_01436690_csv,
-    download_nwis_site_data(file_out = '1_fetch/out/nwis_01436690_data.csv',
-    site_num = '01436690', parameterCd = parameterCd, startDate = startDate, endDate = endDate),
-    format = "file"
+    site_data_01436690,
+    download_nwis_site_data(site_num = '01436690', parameterCd = parameterCd, startDate = startDate, endDate = endDate)
   ),
   tar_target(
-    site_data_01466500_csv,
-    download_nwis_site_data(file_out = '1_fetch/out/nwis_01466500_data.csv',
-    site_num = '01466500', parameterCd = parameterCd, startDate = startDate, endDate = endDate), 
-    format = "file"
+    site_data_01466500,
+    download_nwis_site_data(site_num = '01466500', parameterCd = parameterCd, startDate = startDate, endDate = endDate)
   ), 
   tar_target(
-    site_data,
-    sites_csvs(c(site_data_01427207_csv, site_data_01432160_csv, site_data_01436690_csv, site_data_01466500_csv))
+    site_data_csv,
+    sites(input = list(site_data_01427207, site_data_01432160, site_data_01436690, site_data_01466500),
+    file_out = "1_fetch/out/site_data.csv"),
+    format = "file"
   ),
   tar_target(
     site_info_csv,
-    nwis_site_info(file_out = "1_fetch/out/site_info.csv", site_data),
+    nwis_site_info(file_out = "1_fetch/out/site_info.csv", site_data=site_data_csv),
     format = "file"
   )
 )
@@ -50,7 +44,7 @@ p1_targets_list <- list(
 p2_targets_list <- list(
   tar_target(
     site_data_process_style, 
-    process_data(file_in = site_data, site_filename = site_info_csv)
+    process_data(file_in = site_data_csv, site_filename = site_info_csv)
   )
 )
 


### PR DESCRIPTION
### Overview
Following along with issue #8, I updated the 4 site data download targets to be objects instead of file formats. I also updated the ```site_data_csv``` target to be a file instead of object format.

### Summary
- updated roxygen skeletons to relect changes in ```parms``` and ```export```. 
- edited ```get_nwis_data.R``` function by removing ```file_out``` parameter and updating binding function to return ```site_data.csv``` that then is used as an input in the ```site_data_process_style``` target.
- edited ```process_and_style``` function to be able to read in the the ```site_data_csv``` file format